### PR TITLE
Pass &interrupt_guard_condition_ to the executor_notifier_

### DIFF
--- a/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
+++ b/irobot_events_executor/src/rclcpp/executors/events_executor/events_executor.cpp
@@ -45,7 +45,7 @@ EventsExecutor::EventsExecutor(
   // The added guard conditions are guaranteed to not go out of scope before the executor itself.
   executor_notifier_ = std::make_shared<EventsExecutorNotifyWaitable>();
   executor_notifier_->add_guard_condition(shutdown_guard_condition_.get());
-  executor_notifier_->add_guard_condition(interrupt_guard_condition_.get());
+  executor_notifier_->add_guard_condition(&interrupt_guard_condition_);
 
   entities_collector_->add_waitable(executor_notifier_);
 }


### PR DESCRIPTION
The get() method was causing the code not to compile.